### PR TITLE
interface and windows specific to get registry info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # bookish-memory
-experiment
+experiment for getting history/forensic info from a system 
+intended systems desktop OS 
+- windows
+- macos 
+
+TODO features 
+Minimum information to collect from a system
+- get space from a mount point
+- get history of usb storage devices connected to a desktop
+- bluetooth devices info
+- active networks
+- active applications for current user

--- a/cmd/space/main.go
+++ b/cmd/space/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	fs "gihub.com/leofigy/bookish-memory/fs"
+	"gihub.com/leofigy/bookish-memory/usb"
 )
 
 func main() {
@@ -13,4 +14,15 @@ func main() {
 		return
 	}
 	fmt.Println(inf.GetSpace())
+
+	usbdev := usb.NewInspektor()
+
+	items, err := usbdev.GetDevicesHistory()
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		for _, r := range items {
+			fmt.Println(r.FriendlyName)
+		}
+	}
 }

--- a/usb/usb.go
+++ b/usb/usb.go
@@ -7,6 +7,6 @@ type Info struct {
 	FriendlyName    string
 }
 
-type USB interface {
-	GetHistory() Info
+type USBInspektor interface {
+	GetDevicesHistory() ([]Info, error)
 }

--- a/usb/usb.go
+++ b/usb/usb.go
@@ -1,0 +1,12 @@
+package usb
+
+import "time"
+
+type Info struct {
+	LastTimeUpdated time.Time
+	FriendlyName    string
+}
+
+type USB interface {
+	GetHistory() Info
+}

--- a/usb/usb_unix.go
+++ b/usb/usb_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package usb
+
+// TODO just placeholder to avoid breaking the functionality on nix
+type NixInspector struct{}
+
+func NewInspektor() USBInspektor {
+	return &NixInspector{}
+}
+
+func (s *NixInspector) GetDevicesHistory() ([]Info, error) {
+	return make([]Info, 0), nil
+}

--- a/usb/usb_win.go
+++ b/usb/usb_win.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package usb
+
+import (
+	"fmt"
+	"log"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const (
+	registryEntry = "SYSTEM\\CurrentControlSet\\Enum\\USBSTOR"
+	readAccess    = registry.ENUMERATE_SUB_KEYS | registry.QUERY_VALUE
+)
+
+func GetUSBKey(path string) (*registry.Key, error) {
+	reg, err := registry.OpenKey(registry.LOCAL_MACHINE, path, readAccess)
+
+	if err != nil {
+		// soft error
+		if err == registry.ErrNotExist {
+			log.Println(err)
+			return nil, err
+		}
+
+		fmt.Printf("Failed to open '%s' Error: %v", path, err)
+		return nil, err
+	}
+
+	return &reg, nil
+}

--- a/usb/usb_win_test.go
+++ b/usb/usb_win_test.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package usb
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func TestGetUSBK(t *testing.T) {
+
+	key, err := GetUSBKey(registryEntry)
+
+	if err != nil && err == registry.ErrNotExist {
+		fmt.Println("soft error this machine has no usb devices connected yet")
+		fmt.Println(err)
+		return
+	}
+
+	if err != nil {
+		fmt.Println(err)
+		t.FailNow()
+	}
+
+	// some usb registry entries found
+	defer key.Close()
+
+	info, err := key.Stat()
+	if err != nil {
+		fmt.Println(err)
+		t.FailNow()
+	}
+
+	fmt.Println("devices", info.SubKeyCount)
+
+	if info.SubKeyCount <= 0 {
+		fmt.Println("no devices here")
+		return
+	}
+
+	// getting subkeys
+	subkeys, err := key.ReadSubKeyNames(int(info.SubKeyCount))
+
+	if err != nil {
+		fmt.Println(err)
+		t.FailNow()
+	}
+
+	for _, k := range subkeys {
+		fmt.Println(k)
+	}
+
+}


### PR DESCRIPTION
quick windows struct to get info from the registry about usb storage devices

```
$ go test
devices 2
Disk&Ven_Kingston&Prod_DataTraveler_2.0&Rev_0000
Disk&Ven_Verbatim&Prod_STORE_N_GO&Rev_5.00
PASS
ok      gihub.com/leofigy/bookish-memory/usb    0.392s

```

```
PS C:\Users\leofi\repos\bookish-memory\cmd\space> .\space.exe
{511278637056 98752155648}
Disk&Ven_Kingston&Prod_DataTraveler_2.0&Rev_0000
Disk&Ven_Verbatim&Prod_STORE_N_GO&Rev_5.00
```

Fixes #5 